### PR TITLE
Fix VS2022 Support

### DIFF
--- a/src/PackageInstaller.csproj
+++ b/src/PackageInstaller.csproj
@@ -139,16 +139,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" ExcludeAssets="Runtime">
-      <Version>17.0.0-previews-4-31709-430</Version>
+      <Version>17.12.40392</Version>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.1.9-preview1</Version>
+      <Version>17.12.2069</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.VisualStudio" ExcludeAssets="Runtime">
-      <Version>3.3.0</Version>
+      <Version>17.12.1</Version>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/source.extension.cs
+++ b/src/source.extension.cs
@@ -11,7 +11,7 @@ namespace PackageInstaller
         public const string Name = "Package Installer";
         public const string Description = @"Makes it easier, faster and more convenient than ever to install Bower, npm, Yarn, JSPM, TSD, Typings and NuGet packages to any project";
         public const string Language = "en-US";
-        public const string Version = "2.1.1";
+        public const string Version = "2.2.0";
         public const string Author = "Mads Kristensen";
         public const string Tags = "npm, bower, jspm, nuget, tsd, DefinitelyTyped, Yarn";
     }

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="6ffd6f4d-bbe0-489a-8f6a-33f440773f14" Version="2.1.1" Language="en-US" Publisher="Mads Kristensen" />
-    <DisplayName>Package Installer</DisplayName>
-    <Description xml:space="preserve">Makes it easier, faster and more convenient than ever to install Bower, npm, Yarn, JSPM, TSD, Typings and NuGet packages to any project</Description>
-    <MoreInfo>https://visualstudiogallery.msdn.microsoft.com/753b9720-1638-4f9a-ad8d-2c45a410fd74</MoreInfo>
-    <License>Resources\LICENSE</License>
-    <ReleaseNotes>https://github.com/madskristensen/PackageInstaller/blob/master/CHANGELOG.md</ReleaseNotes>
-    <Icon>Resources\icon.png</Icon>
-    <PreviewImage>Resources\preview.png</PreviewImage>
-    <Tags>npm, bower, jspm, nuget, tsd, DefinitelyTyped, Yarn</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="6ffd6f4d-bbe0-489a-8f6a-33f440773f14" Version="2.2.0" Language="en-US" Publisher="Mads Kristensen" />
+        <DisplayName>Package Installer</DisplayName>
+        <Description xml:space="preserve">Makes it easier, faster and more convenient than ever to install Bower, npm, Yarn, JSPM, TSD, Typings and NuGet packages to any project</Description>
+        <MoreInfo>https://visualstudiogallery.msdn.microsoft.com/753b9720-1638-4f9a-ad8d-2c45a410fd74</MoreInfo>
+        <License>Resources\LICENSE</License>
+        <ReleaseNotes>https://github.com/madskristensen/PackageInstaller/blob/master/CHANGELOG.md</ReleaseNotes>
+        <Icon>Resources\icon.png</Icon>
+        <PreviewImage>Resources\preview.png</PreviewImage>
+        <Tags>npm, bower, jspm, nuget, tsd, DefinitelyTyped, Yarn</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
Fixes #34 , Fixes #36

To run the build locally update NuGet package references for the following packages to latest versions; were using a preview version
- Microsoft.VisualStudio.SDK
- Microsoft.VSSDK.BuildTools

And updated the package reference from an obsolete version
- NuGet.VisualStudio

Tested in VS 2022 17.12.1